### PR TITLE
chore: adding github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: "\U0001F41C Bug report"
+about: Report a reproducible bug.
+title: ''
+labels: new-bug
+assignees: ''
+---
+
+### Subject of the issue
+
+<!-- Describe your issue here. -->
+
+### Your environment
+
+<!--
+* Please provide the output of `algokit doctor` command response,
+* This will give us a good idea about your environment
+-->
+
+### Steps to reproduce
+
+1.
+2.
+
+### Expected behaviour
+
+### Actual behaviour

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41C Bug report"
 about: Report a reproducible bug.
 title: ''
-labels: new-bug
+labels: bug
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: "\U0001F514 Feature Request"
 about: Suggestions for how we can improve the algorand platform.
 title: ''
-labels: new-feature-request
+labels: enhancement
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: "\U0001F514 Feature Request"
+about: Suggestions for how we can improve the algorand platform.
+title: ''
+labels: new-feature-request
+assignees: ''
+---
+
+## Problem
+
+<!-- What is the problem that we’re trying to solve? -->
+
+## Solution
+
+<!-- Do you have a potential/suggested solution? Document more than one if possible. -->
+
+### Proposal
+
+<!-- Describe the solution you’d like in detail. -->
+
+### Pros and Cons
+
+<!-- What are the advantages and disadvantages of this solution? -->
+
+## Dependencies
+
+<!-- Does the solution have any team or design dependencies? -->


### PR DESCRIPTION
## Proposed Changes

- Adding issue templates that are already present on utilts-ts, should make it easier for us to resolve customer issues faster, given that we almost always need info like algokit doctor ouput and etc