### PR TITLE
fix: remove decoding of `rekey_to` address in beta composer

### DIFF
--- a/src/algokit_utils/beta/composer.py
+++ b/src/algokit_utils/beta/composer.py
@@ -388,7 +388,7 @@ class AlgokitComposer:
         if params.lease:
             txn.lease = params.lease
         if params.rekey_to:
-            txn.rekey_to = algosdk.encoding.decode_address(params.rekey_to)  # type: ignore[no-untyped-call]
+            txn.rekey_to = params.rekey_to
         if params.note:
             txn.note = params.note
 


### PR DESCRIPTION
## Proposed Changes

- There is an error when using `rekey_to` address in `beta/composer.py` because the address is decoded in the composer and passed to `Transaction`, which decodes it again.
- Remove decoding in `beta/composer.py.` 
