### PR TITLE
chore: test v3 pypi release trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install algokit-utils
 
 ## Migration from `v2.x` to `v3.x`
 
-Refer to the [v3 migration guide](./docs/source/v3-migration-guide.md) for more information on how to migrate to latest version of `algokit-utils-py`.
+Refer to the [v3 migration](./docs/source/v3-migration-guide.md) for more information on how to migrate to latest version of `algokit-utils-py`.
 
 ## Guiding principles
 


### PR DESCRIPTION
Previous attempt to publish 3.0.0b1 failed with `Upload to artifact repository has failed: 400 Client Error: This filename has already been used, use a different version.`. Even though no such verison exists on pypi. 
If this pr triggering 3.0.0b2 fails again it might be related to pypi access token misconfiguration. Hence, the test pr to attempt to validate this