### PR TITLE
fix: addressing feedback and minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Largely these functions wrap the underlying Algorand SDK, but provide a higher l
 > **Note**
 > If you prefer TypeScript there's an equivalent [TypeScript utility library](https://github.com/algorandfoundation/algokit-utils-ts).
 
-[Install](https://github.com/algorandfoundation/algokit-utils-py#install) | [Documentation](https://algorandfoundation.github.io/algokit-utils-py/html/index.html)
+[Install](https://github.com/algorandfoundation/algokit-utils-py#install) | [Documentation](https://algorandfoundation.github.io/algokit-utils-py)
 
 ## Install
 

--- a/docs/markdown/autoapi/algokit_utils/accounts/account_manager/index.md
+++ b/docs/markdown/autoapi/algokit_utils/accounts/account_manager/index.md
@@ -198,7 +198,7 @@ Note: If you are generating accounts via the various methods on AccountManager
 
 ```pycon
 >>> account_manager = AccountManager(client_manager)
->>> account_manager.set_signer_from_account(SigningAccount.new_account())
+>>> account_manager.set_signer_from_account(SigningAccount(private_key=algosdk.account.generate_account()[0]))
 >>> account_manager.set_signer_from_account(LogicSigAccount(AlgosdkLogicSigAccount(program, args)))
 >>> account_manager.set_signer_from_account(MultiSigAccount(multisig_params, [account1, account2]))
 ```

--- a/docs/markdown/autoapi/algokit_utils/applications/app_factory/index.md
+++ b/docs/markdown/autoapi/algokit_utils/applications/app_factory/index.md
@@ -4,12 +4,12 @@
 
 | [`AppFactoryParams`](#algokit_utils.applications.app_factory.AppFactoryParams)                                           |                                                     |
 |--------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| [`AppFactoryCreateParams`](#algokit_utils.applications.app_factory.AppFactoryCreateParams)                               |                                                     |
-| [`AppFactoryCreateMethodCallParams`](#algokit_utils.applications.app_factory.AppFactoryCreateMethodCallParams)           |                                                     |
+| [`AppFactoryCreateParams`](#algokit_utils.applications.app_factory.AppFactoryCreateParams)                               | Schema for application creation.                    |
+| [`AppFactoryCreateMethodCallParams`](#algokit_utils.applications.app_factory.AppFactoryCreateMethodCallParams)           | Schema for application creation.                    |
 | [`AppFactoryCreateMethodCallResult`](#algokit_utils.applications.app_factory.AppFactoryCreateMethodCallResult)           | Base class for transaction results.                 |
-| [`SendAppFactoryTransactionResult`](#algokit_utils.applications.app_factory.SendAppFactoryTransactionResult)             |                                                     |
-| [`SendAppUpdateFactoryTransactionResult`](#algokit_utils.applications.app_factory.SendAppUpdateFactoryTransactionResult) |                                                     |
-| [`SendAppCreateFactoryTransactionResult`](#algokit_utils.applications.app_factory.SendAppCreateFactoryTransactionResult) |                                                     |
+| [`SendAppFactoryTransactionResult`](#algokit_utils.applications.app_factory.SendAppFactoryTransactionResult)             | Result of an application transaction.               |
+| [`SendAppUpdateFactoryTransactionResult`](#algokit_utils.applications.app_factory.SendAppUpdateFactoryTransactionResult) | Result of updating an application.                  |
+| [`SendAppCreateFactoryTransactionResult`](#algokit_utils.applications.app_factory.SendAppCreateFactoryTransactionResult) | Result of creating a new application.               |
 | [`AppFactoryDeployResult`](#algokit_utils.applications.app_factory.AppFactoryDeployResult)                               | Result from deploying an application via AppFactory |
 | [`AppFactory`](#algokit_utils.applications.app_factory.AppFactory)                                                       |                                                     |
 
@@ -35,9 +35,21 @@
 
 Bases: `_AppFactoryCreateBaseParams`, [`algokit_utils.applications.app_client.AppClientBareCallParams`](../app_client/index.md#algokit_utils.applications.app_client.AppClientBareCallParams)
 
+Schema for application creation.
+
+* **Variables:**
+  * **extra_program_pages** – Optional number of extra program pages
+  * **schema** – Optional application creation schema
+
 ### *class* algokit_utils.applications.app_factory.AppFactoryCreateMethodCallParams
 
 Bases: `_AppFactoryCreateBaseParams`, [`algokit_utils.applications.app_client.AppClientMethodCallParams`](../app_client/index.md#algokit_utils.applications.app_client.AppClientMethodCallParams)
+
+Schema for application creation.
+
+* **Variables:**
+  * **extra_program_pages** – Optional number of extra program pages
+  * **schema** – Optional application creation schema
 
 ### *class* algokit_utils.applications.app_factory.AppFactoryCreateMethodCallResult
 
@@ -61,13 +73,25 @@ Represents the result of sending a single transaction.
 
 Bases: [`algokit_utils.transactions.transaction_sender.SendAppTransactionResult`](../../transactions/transaction_sender/index.md#algokit_utils.transactions.transaction_sender.SendAppTransactionResult)[[`algokit_utils.applications.abi.Arc56ReturnValueType`](../abi/index.md#algokit_utils.applications.abi.Arc56ReturnValueType)]
 
+Result of an application transaction.
+
+Contains the ABI return value if applicable.
+
 ### *class* algokit_utils.applications.app_factory.SendAppUpdateFactoryTransactionResult
 
 Bases: [`algokit_utils.transactions.transaction_sender.SendAppUpdateTransactionResult`](../../transactions/transaction_sender/index.md#algokit_utils.transactions.transaction_sender.SendAppUpdateTransactionResult)[[`algokit_utils.applications.abi.Arc56ReturnValueType`](../abi/index.md#algokit_utils.applications.abi.Arc56ReturnValueType)]
 
+Result of updating an application.
+
+Contains the compiled approval and clear programs.
+
 ### *class* algokit_utils.applications.app_factory.SendAppCreateFactoryTransactionResult
 
 Bases: [`algokit_utils.transactions.transaction_sender.SendAppCreateTransactionResult`](../../transactions/transaction_sender/index.md#algokit_utils.transactions.transaction_sender.SendAppCreateTransactionResult)[[`algokit_utils.applications.abi.Arc56ReturnValueType`](../abi/index.md#algokit_utils.applications.abi.Arc56ReturnValueType)]
+
+Result of creating a new application.
+
+Contains the app ID and address of the newly created application.
 
 ### *class* algokit_utils.applications.app_factory.AppFactoryDeployResult
 

--- a/src/algokit_utils/accounts/account_manager.py
+++ b/src/algokit_utils/accounts/account_manager.py
@@ -222,7 +222,7 @@ class AccountManager:
 
         :example:
         >>> account_manager = AccountManager(client_manager)
-        >>> account_manager.set_signer_from_account(SigningAccount.new_account())
+        >>> account_manager.set_signer_from_account(SigningAccount(private_key=algosdk.account.generate_account()[0]))
         >>> account_manager.set_signer_from_account(LogicSigAccount(AlgosdkLogicSigAccount(program, args)))
         >>> account_manager.set_signer_from_account(MultiSigAccount(multisig_params, [account1, account2]))
         """
@@ -449,8 +449,8 @@ class AccountManager:
         :example:
         >>> account = account_manager.random()
         """
-        account = SigningAccount.new_account()
-        return self._register_account(account.private_key)
+        private_key, _ = algosdk.account.generate_account()
+        return self._register_account(private_key)
 
     def localnet_dispenser(self) -> SigningAccount:
         """

--- a/src/algokit_utils/application_specification.py
+++ b/src/algokit_utils/application_specification.py
@@ -1,6 +1,6 @@
 import warnings
 
-from deprecated import deprecated
+from typing_extensions import deprecated
 
 warnings.warn(
     """The legacy v2 application_specification module is deprecated and will be removed in a future version.

--- a/src/algokit_utils/applications/app_client.py
+++ b/src/algokit_utils/applications/app_client.py
@@ -5,7 +5,7 @@ import copy
 import json
 import os
 from collections.abc import Sequence
-from dataclasses import dataclass, fields
+from dataclasses import asdict, dataclass, fields
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypedDict, TypeVar
 
 import algosdk
@@ -799,14 +799,12 @@ class _MethodParamsBuilder:
         :param compilation_params: Parameters for the compilation, defaults to None
         :return: Parameters for updating the application
         """
-        compile_params = (
+        compile_params = asdict(
             self._client.compile(
                 app_spec=self._client.app_spec,
                 app_manager=self._algorand.app,
                 compilation_params=compilation_params,
-            ).__dict__
-            if compilation_params
-            else {}
+            )
         )
 
         input_params = {

--- a/src/algokit_utils/models/account.py
+++ b/src/algokit_utils/models/account.py
@@ -5,6 +5,7 @@ import algosdk.atomic_transaction_composer
 from algosdk.atomic_transaction_composer import AccountTransactionSigner, LogicSigTransactionSigner, TransactionSigner
 from algosdk.transaction import LogicSigAccount as AlgosdkLogicSigAccount
 from algosdk.transaction import Multisig, MultisigTransaction
+from typing_extensions import deprecated
 
 __all__ = [
     "DISPENSER_ACCOUNT_NAME",
@@ -66,6 +67,9 @@ class SigningAccount:
         """
         return AccountTransactionSigner(self.private_key)
 
+    @deprecated(
+        "Use `algorand.account.random()` or `SigningAccount(private_key=algosdk.account.generate_account()[0])` instead"
+    )
     @staticmethod
     def new_account() -> "SigningAccount":
         """Create a new random account.

--- a/src/algokit_utils/transactions/transaction_sender.py
+++ b/src/algokit_utils/transactions/transaction_sender.py
@@ -245,12 +245,12 @@ class AlgorandClientTransactionSender:
             compiled_approval = (
                 self._app_manager.get_compilation_result(params.approval_program)
                 if isinstance(params.approval_program, str)
-                else None
+                else params.approval_program
             )
             compiled_clear = (
                 self._app_manager.get_compilation_result(params.clear_state_program)
                 if isinstance(params.clear_state_program, str)
-                else None
+                else params.clear_state_program
             )
 
             return SendAppUpdateTransactionResult[ABIReturn](


### PR DESCRIPTION
- Added extra deprecation for new_account staticmethod on SigningAccount (which was previously called Account in legacy v2 interfaces). Given that now algorand client provides access to manager that allows creation of accounts via random() im deprecating it too -> which should make it a further aligned with ts utils
- Fixing broken link on readme pointing to self hosted docs, since jekyl was disabled to fix css the end url slightly changed 
- Fixing minor typo in update method call where compilation would be skipped, resulting in a response that lacks compiled and clear approvals
- Addressing feedback that revealed a small bug in extra program pages calculation