### PR TITLE
fix: expose algosdk lsig, multisig object instances in account wrappers

### DIFF
--- a/.github/actions/setup-poetry/action.yaml
+++ b/.github/actions/setup-poetry/action.yaml
@@ -9,6 +9,7 @@ runs:
     - if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
       run: |
         pip install poetry
+        pip install poetry-plugin-export
       shell: bash
 
     # NOTE: Below commands currently causes a faulty behaviour in pipx where
@@ -24,6 +25,7 @@ runs:
     - if: ${{ runner.os != 'macOS' || runner.arch != 'ARM64' }}
       run: |
         pipx install poetry ${{ runner.os == 'macOS' && '--python "$Python_ROOT_DIR/bin/python"' || '' }}
+        pipx inject poetry poetry-plugin-export
       shell: bash
 
     - name: Get full Python version

--- a/docs/markdown/autoapi/algokit_utils/accounts/account_manager/index.md
+++ b/docs/markdown/autoapi/algokit_utils/accounts/account_manager/index.md
@@ -322,7 +322,7 @@ Tracks and returns an Algorand account with private key loaded from the given KM
   ... )
   ```
 
-#### logicsig(program: bytes, args: list[bytes] | None = None) → algokit_utils.models.account.LogicSigAccount
+#### logicsig(program: bytes, args: list[bytes] | None = None) → [algokit_utils.models.account.LogicSigAccount](../../models/account/index.md#algokit_utils.models.account.LogicSigAccount)
 
 Tracks and returns an account that represents a logic signature.
 

--- a/docs/markdown/autoapi/algokit_utils/models/account/index.md
+++ b/docs/markdown/autoapi/algokit_utils/models/account/index.md
@@ -12,6 +12,7 @@
 | [`SigningAccount`](#algokit_utils.models.account.SigningAccount)                       | Holds the private key and address for an account.               |
 | [`MultisigMetadata`](#algokit_utils.models.account.MultisigMetadata)                   | Metadata for a multisig account.                                |
 | [`MultiSigAccount`](#algokit_utils.models.account.MultiSigAccount)                     | Account wrapper that supports partial or full multisig signing. |
+| [`LogicSigAccount`](#algokit_utils.models.account.LogicSigAccount)                     | Account wrapper that supports logic sig signing.                |
 
 ## Module Contents
 
@@ -82,6 +83,13 @@ Provides functionality to manage and sign transactions for a multisig account.
   * **multisig_params** – The parameters for the multisig account
   * **signing_accounts** – The list of accounts that can sign
 
+#### *property* multisig *: algosdk.transaction.Multisig*
+
+Get the underlying algosdk.transaction.Multisig object instance.
+
+* **Returns:**
+  The algosdk.transaction.Multisig object instance
+
 #### *property* params *: [MultisigMetadata](#algokit_utils.models.account.MultisigMetadata)*
 
 Get the parameters for the multisig account.
@@ -118,3 +126,30 @@ Sign the given transaction with all present signers.
   **transaction** – Either a transaction object or a raw, partially signed transaction
 * **Returns:**
   The transaction signed by the present signers
+
+### *class* algokit_utils.models.account.LogicSigAccount(account: algosdk.transaction.LogicSigAccount)
+
+Account wrapper that supports logic sig signing.
+
+Provides functionality to manage and sign transactions for a logic sig account.
+
+#### *property* lsig *: algosdk.transaction.LogicSigAccount*
+
+Get the underlying algosdk.transaction.LogicSigAccount object instance.
+
+* **Returns:**
+  The algosdk.transaction.LogicSigAccount object instance
+
+#### *property* address *: str*
+
+Get the address of the logic sig account.
+
+* **Returns:**
+  The logic sig account address
+
+#### *property* signer *: algosdk.atomic_transaction_composer.LogicSigTransactionSigner*
+
+Get the transaction signer for this multisig account.
+
+* **Returns:**
+  The multisig transaction signer

--- a/docs/markdown/autoapi/algokit_utils/models/account/index.md
+++ b/docs/markdown/autoapi/algokit_utils/models/account/index.md
@@ -127,7 +127,7 @@ Sign the given transaction with all present signers.
 * **Returns:**
   The transaction signed by the present signers
 
-### *class* algokit_utils.models.account.LogicSigAccount(account: algosdk.transaction.LogicSigAccount)
+### *class* algokit_utils.models.account.LogicSigAccount(program: bytes, args: list[bytes] | None)
 
 Account wrapper that supports logic sig signing.
 
@@ -143,6 +143,11 @@ Get the underlying algosdk.transaction.LogicSigAccount object instance.
 #### *property* address *: str*
 
 Get the address of the logic sig account.
+
+If the LogicSig is delegated to another account, this will return the address of that account.
+
+If the LogicSig is not delegated to another account, this will return an escrow address that is the hash of
+the LogicSig’s program code.
 
 * **Returns:**
   The logic sig account address

--- a/docs/markdown/capabilities/account.md
+++ b/docs/markdown/capabilities/account.md
@@ -22,7 +22,7 @@ The following conform to `TransactionSignerAccountProtocol`:
 
 - [`TransactionSignerAccount`](../autoapi/algokit_utils/models/account/index.md#algokit_utils.models.account.TransactionSignerAccount) - a basic transaction signer account that holds an address and a signer conforming to `TransactionSignerAccountProtocol`
 - [`SigningAccount`](../autoapi/algokit_utils/models/account/index.md#algokit_utils.models.account.SigningAccount) - an abstraction that used to be available under `Account` in previous versions of AlgoKit Utils. Renamed for consistency with equivalent `ts` version. Holds private key and conforms to `TransactionSignerAccountProtocol`
-- `LogicSigAccount` - a wrapper class around `algosdk` logicsig abstractions conforming to `TransactionSignerAccountProtocol`
+- [`LogicSigAccount`](../autoapi/algokit_utils/models/account/index.md#algokit_utils.models.account.LogicSigAccount) - a wrapper class around `algosdk` logicsig abstractions conforming to `TransactionSignerAccountProtocol`
 - `MultisigAccount` - a wrapper class around `algosdk` multisig abstractions conforming to `TransactionSignerAccountProtocol`
 
 ## Registering a signer
@@ -89,8 +89,8 @@ While `TransactionSignerAccount` is the main class used to represent an account 
 
 - [`TransactionSignerAccount`](../autoapi/algokit_utils/models/account/index.md#algokit_utils.models.account.TransactionSignerAccount) - A default class conforming to `TransactionSignerAccountProtocol` that holds an address and a signer
 - [`SigningAccount`](../autoapi/algokit_utils/models/account/index.md#algokit_utils.models.account.SigningAccount) - An abstraction around `algosdk.Account` that supports rekeyed accounts
-- `LogicSigAccount` - An in-built algosdk `algosdk.LogicSigAccount` object
-- `MultisigAccount` - An abstraction around `algosdk.MultisigMetadata`, `algosdk.makeMultiSigAccountTransactionSigner`, `algosdk.multisigAddress`, `algosdk.signMultisigTransaction` and `algosdk.appendSignMultisigTransaction` that supports multisig accounts with one or more signers present
+- [`LogicSigAccount`](../autoapi/algokit_utils/models/account/index.md#algokit_utils.models.account.LogicSigAccount) - An abstraction around `algosdk.LogicSigAccount` and `algosdk.LogicSig` that supports logic sig signing. Exposes access to the underlying algosdk `algosdk.transaction.LogicSigAccount` object instance via `lsig` property.
+- `MultisigAccount` - An abstraction around `algosdk.MultisigMetadata`, `algosdk.makeMultiSigAccountTransactionSigner`, `algosdk.multisigAddress`, `algosdk.signMultisigTransaction` and `algosdk.appendSignMultisigTransaction` that supports multisig accounts with one or more signers present. Exposes access to the underlying algosdk `algosdk.transaction.Multisig` object instance via `multisig` property.
 
 ### Dispenser
 

--- a/docs/source/capabilities/account.md
+++ b/docs/source/capabilities/account.md
@@ -89,8 +89,8 @@ While `TransactionSignerAccount` is the main class used to represent an account 
 
 - {py:obj}`TransactionSignerAccount <algokit_utils.models.account.TransactionSignerAccount>` - A default class conforming to `TransactionSignerAccountProtocol` that holds an address and a signer
 - {py:obj}`SigningAccount <algokit_utils.models.account.SigningAccount>` - An abstraction around `algosdk.Account` that supports rekeyed accounts
-- {py:obj}`LogicSigAccount <algokit_utils.models.account.LogicSigAccount>` - An in-built algosdk `algosdk.LogicSigAccount` object
-- {py:obj}`MultisigAccount <algokit_utils.models.account.MultisigAccount>` - An abstraction around `algosdk.MultisigMetadata`, `algosdk.makeMultiSigAccountTransactionSigner`, `algosdk.multisigAddress`, `algosdk.signMultisigTransaction` and `algosdk.appendSignMultisigTransaction` that supports multisig accounts with one or more signers present
+- {py:obj}`LogicSigAccount <algokit_utils.models.account.LogicSigAccount>` - An abstraction around `algosdk.LogicSigAccount` and `algosdk.LogicSig` that supports logic sig signing. Exposes access to the underlying algosdk `algosdk.transaction.LogicSigAccount` object instance via `lsig` property.
+- {py:obj}`MultisigAccount <algokit_utils.models.account.MultisigAccount>` - An abstraction around `algosdk.MultisigMetadata`, `algosdk.makeMultiSigAccountTransactionSigner`, `algosdk.multisigAddress`, `algosdk.signMultisigTransaction` and `algosdk.appendSignMultisigTransaction` that supports multisig accounts with one or more signers present. Exposes access to the underlying algosdk `algosdk.transaction.Multisig` object instance via `multisig` property.
 
 ### Dispenser
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -449,38 +449,42 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "44.0.0"
+version = "44.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.7"
 files = [
-    {file = "cryptography-44.0.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:84111ad4ff3f6253820e6d3e58be2cc2a00adb29335d4cacb5ab4d4d34f2a123"},
-    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b15492a11f9e1b62ba9d73c210e2416724633167de94607ec6069ef724fad092"},
-    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:831c3c4d0774e488fdc83a1923b49b9957d33287de923d58ebd3cec47a0ae43f"},
-    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb"},
-    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b"},
-    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543"},
-    {file = "cryptography-44.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e"},
-    {file = "cryptography-44.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e"},
-    {file = "cryptography-44.0.0-cp37-abi3-win32.whl", hash = "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053"},
-    {file = "cryptography-44.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:abc998e0c0eee3c8a1904221d3f67dcfa76422b23620173e28c11d3e626c21bd"},
-    {file = "cryptography-44.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:660cb7312a08bc38be15b696462fa7cc7cd85c3ed9c576e81f4dc4d8b2b31591"},
-    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1923cb251c04be85eec9fda837661c67c1049063305d6be5721643c22dd4e2b7"},
-    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:404fdc66ee5f83a1388be54300ae978b2efd538018de18556dde92575e05defc"},
-    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289"},
-    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7"},
-    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c"},
-    {file = "cryptography-44.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64"},
-    {file = "cryptography-44.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285"},
-    {file = "cryptography-44.0.0-cp39-abi3-win32.whl", hash = "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417"},
-    {file = "cryptography-44.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:708ee5f1bafe76d041b53a4f95eb28cdeb8d18da17e597d46d7833ee59b97ede"},
-    {file = "cryptography-44.0.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:37d76e6863da3774cd9db5b409a9ecfd2c71c981c38788d3fcfaf177f447b731"},
-    {file = "cryptography-44.0.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:f677e1268c4e23420c3acade68fac427fffcb8d19d7df95ed7ad17cdef8404f4"},
-    {file = "cryptography-44.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f5e7cb1e5e56ca0933b4873c0220a78b773b24d40d186b6738080b73d3d0a756"},
-    {file = "cryptography-44.0.0-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:8b3e6eae66cf54701ee7d9c83c30ac0a1e3fa17be486033000f2a73a12ab507c"},
-    {file = "cryptography-44.0.0-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:be4ce505894d15d5c5037167ffb7f0ae90b7be6f2a98f9a5c3442395501c32fa"},
-    {file = "cryptography-44.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:62901fb618f74d7d81bf408c8719e9ec14d863086efe4185afd07c352aee1d2c"},
-    {file = "cryptography-44.0.0.tar.gz", hash = "sha256:cd4e834f340b4293430701e772ec543b0fbe6c2dea510a5286fe0acabe153a02"},
+    {file = "cryptography-44.0.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf688f615c29bfe9dfc44312ca470989279f0e94bb9f631f85e3459af8efc009"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd7c7e2d71d908dc0f8d2027e1604102140d84b155e658c20e8ad1304317691f"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:887143b9ff6bad2b7570da75a7fe8bbf5f65276365ac259a5d2d5147a73775f2"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:322eb03ecc62784536bc173f1483e76747aafeb69c8728df48537eb431cd1911"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:21377472ca4ada2906bc313168c9dc7b1d7ca417b63c1c3011d0c74b7de9ae69"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:df978682c1504fc93b3209de21aeabf2375cb1571d4e61907b3e7a2540e83026"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:eb3889330f2a4a148abead555399ec9a32b13b7c8ba969b72d8e500eb7ef84cd"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8e6a85a93d0642bd774460a86513c5d9d80b5c002ca9693e63f6e540f1815ed0"},
+    {file = "cryptography-44.0.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6f76fdd6fd048576a04c5210d53aa04ca34d2ed63336d4abd306d0cbe298fddf"},
+    {file = "cryptography-44.0.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6c8acf6f3d1f47acb2248ec3ea261171a671f3d9428e34ad0357148d492c7864"},
+    {file = "cryptography-44.0.1-cp37-abi3-win32.whl", hash = "sha256:24979e9f2040c953a94bf3c6782e67795a4c260734e5264dceea65c8f4bae64a"},
+    {file = "cryptography-44.0.1-cp37-abi3-win_amd64.whl", hash = "sha256:fd0ee90072861e276b0ff08bd627abec29e32a53b2be44e41dbcdf87cbee2b00"},
+    {file = "cryptography-44.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a2d8a7045e1ab9b9f803f0d9531ead85f90c5f2859e653b61497228b18452008"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8272f257cf1cbd3f2e120f14c68bff2b6bdfcc157fafdee84a1b795efd72862"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e8d181e90a777b63f3f0caa836844a1182f1f265687fac2115fcf245f5fbec3"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:436df4f203482f41aad60ed1813811ac4ab102765ecae7a2bbb1dbb66dcff5a7"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4f422e8c6a28cf8b7f883eb790695d6d45b0c385a2583073f3cec434cc705e1a"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:72198e2b5925155497a5a3e8c216c7fb3e64c16ccee11f0e7da272fa93b35c4c"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a46a89ad3e6176223b632056f321bc7de36b9f9b93b2cc1cccf935a3849dc62"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:53f23339864b617a3dfc2b0ac8d5c432625c80014c25caac9082314e9de56f41"},
+    {file = "cryptography-44.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:888fcc3fce0c888785a4876ca55f9f43787f4c5c1cc1e2e0da71ad481ff82c5b"},
+    {file = "cryptography-44.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:00918d859aa4e57db8299607086f793fa7813ae2ff5a4637e318a25ef82730f7"},
+    {file = "cryptography-44.0.1-cp39-abi3-win32.whl", hash = "sha256:9b336599e2cb77b1008cb2ac264b290803ec5e8e89d618a5e978ff5eb6f715d9"},
+    {file = "cryptography-44.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:e403f7f766ded778ecdb790da786b418a9f2394f36e8cc8b796cc056ab05f44f"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1f9a92144fa0c877117e9748c74501bea842f93d21ee00b0cf922846d9d0b183"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:610a83540765a8d8ce0f351ce42e26e53e1f774a6efb71eb1b41eb01d01c3d12"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:5fed5cd6102bb4eb843e3315d2bf25fede494509bddadb81e03a859c1bc17b83"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f4daefc971c2d1f82f03097dc6f216744a6cd2ac0f04c68fb935ea2ba2a0d420"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:94f99f2b943b354a5b6307d7e8d19f5c423a794462bde2bf310c770ba052b1c4"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d9c5b9f698a83c8bd71e0f4d3f9f839ef244798e5ffe96febfa9714717db7af7"},
+    {file = "cryptography-44.0.1.tar.gz", hash = "sha256:f51f5705ab27898afda1aaa430f34ad90dc117421057782022edf0600bec5f14"},
 ]
 
 [package.dependencies]
@@ -493,7 +497,7 @@ nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2)"]
 pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
 sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==44.0.0)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==44.0.1)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]

--- a/src/algokit_utils/accounts/account_manager.py
+++ b/src/algokit_utils/accounts/account_manager.py
@@ -7,7 +7,6 @@ import algosdk
 from algosdk import mnemonic
 from algosdk.atomic_transaction_composer import TransactionSigner
 from algosdk.mnemonic import to_private_key
-from algosdk.transaction import LogicSigAccount as AlgosdkLogicSigAccount
 from algosdk.transaction import SuggestedParams
 from typing_extensions import Self
 
@@ -313,7 +312,7 @@ class AccountManager:
         :param args: The (binary) arguments to pass into the logic signature
         :returns: The registered AlgosdkLogicSigAccount instance
         """
-        logic_sig = LogicSigAccount(AlgosdkLogicSigAccount(program, args))
+        logic_sig = LogicSigAccount(program, args)
         self._accounts[logic_sig.address] = logic_sig
         return logic_sig
 

--- a/src/algokit_utils/models/account.py
+++ b/src/algokit_utils/models/account.py
@@ -182,12 +182,10 @@ class LogicSigAccount:
     Provides functionality to manage and sign transactions for a logic sig account.
     """
 
-    _account: AlgosdkLogicSigAccount
     _signer: LogicSigTransactionSigner
 
-    def __init__(self, account: AlgosdkLogicSigAccount) -> None:
-        self._account = account
-        self._signer = LogicSigTransactionSigner(account)
+    def __init__(self, program: bytes, args: list[bytes] | None) -> None:
+        self._signer = LogicSigTransactionSigner(AlgosdkLogicSigAccount(program, args))
 
     @property
     def lsig(self) -> AlgosdkLogicSigAccount:
@@ -195,15 +193,20 @@ class LogicSigAccount:
 
         :return: The `algosdk.transaction.LogicSigAccount` object instance
         """
-        return self._account
+        return self._signer.lsig
 
     @property
     def address(self) -> str:
         """Get the address of the logic sig account.
 
+        If the LogicSig is delegated to another account, this will return the address of that account.
+
+        If the LogicSig is not delegated to another account, this will return an escrow address that is the hash of
+        the LogicSig's program code.
+
         :return: The logic sig account address
         """
-        return self._account.address()
+        return self._signer.lsig.address()
 
     @property
     def signer(self) -> LogicSigTransactionSigner:

--- a/src/algokit_utils/models/account.py
+++ b/src/algokit_utils/models/account.py
@@ -9,6 +9,7 @@ from typing_extensions import deprecated
 
 __all__ = [
     "DISPENSER_ACCOUNT_NAME",
+    "LogicSigAccount",
     "MultiSigAccount",
     "MultisigMetadata",
     "SigningAccount",
@@ -119,6 +120,14 @@ class MultiSigAccount:
         )
 
     @property
+    def multisig(self) -> Multisig:
+        """Get the underlying `algosdk.transaction.Multisig` object instance.
+
+        :return: The `algosdk.transaction.Multisig` object instance
+        """
+        return self._multisig
+
+    @property
     def params(self) -> MultisigMetadata:
         """Get the parameters for the multisig account.
 
@@ -181,10 +190,18 @@ class LogicSigAccount:
         self._signer = LogicSigTransactionSigner(account)
 
     @property
-    def address(self) -> str:
-        """Get the address of the multisig account.
+    def lsig(self) -> AlgosdkLogicSigAccount:
+        """Get the underlying `algosdk.transaction.LogicSigAccount` object instance.
 
-        :return: The multisig account address
+        :return: The `algosdk.transaction.LogicSigAccount` object instance
+        """
+        return self._account
+
+    @property
+    def address(self) -> str:
+        """Get the address of the logic sig account.
+
+        :return: The logic sig account address
         """
         return self._account.address()
 

--- a/src/algokit_utils/transactions/transaction_composer.py
+++ b/src/algokit_utils/transactions/transaction_composer.py
@@ -2111,18 +2111,24 @@ class TransactionComposer:
             if not sdk_params["approval_program"] or not sdk_params["clear_program"]:
                 raise ValueError("approval_program and clear_program are required for application creation")
 
-            if not params.schema:
-                raise ValueError("schema is required for application creation")
+            schema = params.schema
+            if not schema:
+                schema = AppCreateSchema(
+                    global_ints=0,
+                    global_byte_slices=0,
+                    local_ints=0,
+                    local_byte_slices=0,
+                )
 
             txn_params = {
                 **txn_params,
                 "global_schema": algosdk.transaction.StateSchema(
-                    num_uints=params.schema.get("global_ints", 0),
-                    num_byte_slices=params.schema.get("global_byte_slices", 0),
+                    num_uints=schema["global_ints"],
+                    num_byte_slices=schema["global_byte_slices"],
                 ),
                 "local_schema": algosdk.transaction.StateSchema(
-                    num_uints=params.schema.get("local_ints", 0),
-                    num_byte_slices=params.schema.get("local_byte_slices", 0),
+                    num_uints=schema["local_ints"],
+                    num_byte_slices=schema["local_byte_slices"],
                 ),
                 "extra_pages": params.extra_program_pages
                 or calculate_extra_program_pages(approval_program, clear_program),


### PR DESCRIPTION
# Proposed changes

- Addresses feedback on delegated lsigs edge case 
- Ensure default schema is used when not provided in params for app create calls in composer
- Address poetry v2 