### PR TITLE
fix: addressing internal feedback (batch 6) 

### DIFF
--- a/src/algokit_utils/applications/app_client.py
+++ b/src/algokit_utils/applications/app_client.py
@@ -1900,6 +1900,11 @@ class AppClient:
         method = self._app_spec.get_arc56_method(method_name_or_signature)
         result: list[ABIValue | ABIStruct | AppMethodCallTransactionArgument | None] = []
 
+        if args and len(method.args) < len(args):
+            raise ValueError(
+                f"Unexpected arg at position {len(method.args)}. {method.name} only expects {len(method.args)} args"
+            )
+
         for i, method_arg in enumerate(method.args):
             arg_value = args[i] if args and i < len(args) else None
 

--- a/src/algokit_utils/transactions/transaction_composer.py
+++ b/src/algokit_utils/transactions/transaction_composer.py
@@ -706,7 +706,7 @@ def _get_group_execution_info(  # noqa: C901, PLR0912
             )
         failed_at = group_response.get("failed-at", [0])[0]
         raise ValueError(
-            f"Error during resource population simulation in transaction {failed_at}: "
+            f"Error resolving execution info via simulate in transaction {failed_at}: "
             f"{group_response['failure-message']}"
         )
 

--- a/tests/applications/test_app_factory.py
+++ b/tests/applications/test_app_factory.py
@@ -390,6 +390,21 @@ def test_create_then_call_app(factory: AppFactory) -> None:
     assert call.abi_return == "Hello, test"
 
 
+def test_call_app_with_too_many_args(factory: AppFactory) -> None:
+    app_client, _ = factory.send.bare.create(
+        compilation_params={
+            "updatable": False,
+            "deletable": False,
+            "deploy_time_params": {
+                "VALUE": 1,
+            },
+        },
+    )
+
+    with pytest.raises(Exception, match="Unexpected arg at position 1. call_abi only expects 1 args"):
+        app_client.send.call(AppClientMethodCallParams(method="call_abi", args=["test", "extra"]))
+
+
 def test_call_app_with_rekey(funded_account: SigningAccount, algorand: AlgorandClient, factory: AppFactory) -> None:
     rekey_to = algorand.account.random()
 

--- a/tests/transactions/test_resource_packing.py
+++ b/tests/transactions/test_resource_packing.py
@@ -417,7 +417,7 @@ class TestResourcePackerMeta:
                     "populate_app_call_resources": True,
                 },
             )
-        assert "Error during resource population simulation in transaction 0" in exc_info.value.logic_error_str
+        assert "Error resolving execution info via simulate in transaction 0" in exc_info.value.logic_error_str
 
     def test_box_with_txn_arg(self, algorand: AlgorandClient, funded_account: SigningAccount) -> None:
         payment = PaymentTxn(


### PR DESCRIPTION
## Proposed Changes

- ensure root of unnamed resources response is parsed into typed class (which is a root cause of an error reported by Brian)
- align error message thrown during errors in resource population with ts (reported by Neil)
