### PR TITLE
fix: remove deprecation decorator causing side effects

### DIFF
--- a/src/algokit_utils/_legacy_v2/_transfer.py
+++ b/src/algokit_utils/_legacy_v2/_transfer.py
@@ -17,7 +17,6 @@ __all__ = ["TransferAssetParameters", "TransferParameters", "transfer", "transfe
 logger = logging.getLogger(__name__)
 
 
-@deprecated("Send transactions via `algorand.{send|create_transaction}.{txn_type}()` instead")
 @dataclasses.dataclass(kw_only=True)
 class TransferParametersBase:
     """Parameters for transferring µALGOs between accounts.


### PR DESCRIPTION
## Proposed Changes

- Deprecation decorator on the legacy base class was printing warning despite direct usage in end user code. This is due to the fact that it was used as a base class for other legacy abstractions that inherited from it. As part of implicit instantiation the logger was recording the deprecation warning despite class being used directly in the user's codebase, resulting in confusing warnings. Given that its a base class and has not primary uses as a standalone class (mainly leveraged as part of the subclasses) - its safe to remove this specific deprecation decorator.
