### PR TITLE
Box name decode with utf-8 should be optional

### DIFF
--- a/docs/markdown/autoapi/algokit_utils/applications/app_manager/index.md
+++ b/docs/markdown/autoapi/algokit_utils/applications/app_manager/index.md
@@ -133,6 +133,8 @@ Get the local state for an account in an application.
 
 Get names of all boxes for an application.
 
+If the box name can’t be decoded from UTF-8, the string representation of the bytes is returned.
+
 * **Parameters:**
   **app_id** – The application ID
 * **Returns:**

--- a/docs/markdown/autoapi/algokit_utils/models/state/index.md
+++ b/docs/markdown/autoapi/algokit_utils/models/state/index.md
@@ -20,7 +20,7 @@
 
 The name of the box
 
-#### name *: str*
+#### name *: str | None*
 
 The name of the box as a string
 

--- a/docs/markdown/autoapi/algokit_utils/models/state/index.md
+++ b/docs/markdown/autoapi/algokit_utils/models/state/index.md
@@ -20,9 +20,10 @@
 
 The name of the box
 
-#### name *: str | None*
+#### name *: str*
 
-The name of the box as a string
+The name of the box as a string.
+If the name can’t be decoded from UTF-8, the string representation of the bytes is returned instead.
 
 #### name_raw *: bytes*
 

--- a/src/algokit_utils/applications/app_manager.py
+++ b/src/algokit_utils/applications/app_manager.py
@@ -269,6 +269,11 @@ class AppManager:
             >>> app_id = 123
             >>> box_names = app_manager.get_box_names(app_id)
         """
+        def maybe_get_utf8_name(b: bytes) -> str | None:
+            try:
+                return b.decode("utf-8")
+            except UnicodeDecodeError:
+                return None
 
         box_result = self._algod.application_boxes(app_id)
         assert isinstance(box_result, dict)
@@ -276,7 +281,7 @@ class AppManager:
             BoxName(
                 name_raw=base64.b64decode(b["name"]),
                 name_base64=b["name"],
-                name=base64.b64decode(b["name"]).decode("utf-8"),
+                name=maybe_get_utf8_name(base64.b64decode(b["name"])),
             )
             for b in box_result["boxes"]
         ]

--- a/src/algokit_utils/applications/app_manager.py
+++ b/src/algokit_utils/applications/app_manager.py
@@ -269,6 +269,7 @@ class AppManager:
             >>> app_id = 123
             >>> box_names = app_manager.get_box_names(app_id)
         """
+
         def maybe_get_utf8_name(b: bytes) -> str | None:
             try:
                 return b.decode("utf-8")

--- a/src/algokit_utils/models/state.py
+++ b/src/algokit_utils/models/state.py
@@ -21,8 +21,9 @@ __all__ = [
 class BoxName:
     """The name of the box"""
 
-    name: str | None
-    """The name of the box as a string"""
+    name: str
+    """The name of the box as a string.
+    If the name can't be decoded from UTF-8, the string representation of the bytes is returned instead."""
     name_raw: bytes
     """The name of the box as raw bytes"""
     name_base64: str

--- a/src/algokit_utils/models/state.py
+++ b/src/algokit_utils/models/state.py
@@ -21,7 +21,7 @@ __all__ = [
 class BoxName:
     """The name of the box"""
 
-    name: str
+    name: str | None
     """The name of the box as a string"""
     name_raw: bytes
     """The name of the box as raw bytes"""


### PR DESCRIPTION
Since not every box name is encoded with utf-8, this change makes it so the value is only decoded if the result does not error.

This is a breaking change since now the `name` field in a `BoxName` is optional.