### PR TITLE
fix: support app client instantiation from arc4

### DIFF
--- a/tests/applications/test_app_client.py
+++ b/tests/applications/test_app_client.py
@@ -765,6 +765,11 @@ def nested_struct_app_spec() -> Arc56Contract:
     return Arc56Contract.from_json(raw_json_spec.read_text())
 
 
+def test_nested_struct_from_arc4() -> None:
+    raw_json_spec = Path(__file__).parent.parent / "artifacts" / "nested_struct" / "nested_struct.arc4.json"
+    Arc56Contract.from_json(raw_json_spec.read_text())
+
+
 def test_nested_structs_described_by_structure(
     algorand: AlgorandClient, funded_account: SigningAccount, nested_struct_app_spec: Arc56Contract
 ) -> None:

--- a/tests/artifacts/nested_struct/nested_struct.arc4.json
+++ b/tests/artifacts/nested_struct/nested_struct.arc4.json
@@ -1,0 +1,41 @@
+{
+  "name": "NestedStruct",
+  "desc": "",
+  "methods": [
+    {
+      "name": "createApplication",
+      "args": [],
+      "returns": {
+        "type": "void"
+      }
+    },
+    {
+      "name": "setValue",
+      "args": [
+        {
+          "name": "key",
+          "type": "uint64"
+        },
+        {
+          "name": "value",
+          "type": "string"
+        }
+      ],
+      "returns": {
+        "type": "void"
+      }
+    },
+    {
+      "name": "getValue",
+      "args": [
+        {
+          "name": "key",
+          "type": "uint64"
+        }
+      ],
+      "returns": {
+        "type": "((string))"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
An app client created from an ARC4 spec will assume all actions are allowed for all methods (including bare)

Main use case is for older apps that don't have ARC32 or 56 available. Only downside is that generated clients will have more methods available than what is actually supported but I think that is acceptable for users that are using ARC4 specs. 

Fixes #171