### PR TITLE
fix: include v5 migration guide in starlight docs

### DIFF
--- a/docs/src/content/docs/migration/v5-migration-guide.md
+++ b/docs/src/content/docs/migration/v5-migration-guide.md
@@ -1,4 +1,7 @@
-# AlgoKit Utils Python: v5 Migration Guide
+---
+title: "v5 Migration Guide"
+description: "Guide for migrating from algokit-utils-py v4.x to v5.x — from algosdk-dependent to standalone multi-module architecture."
+---
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ cicd = []
 dev = [
   "pip>=26.0,<27",
   "pydantic>=2.0.0,<3",
-  "pytest>=8,<9",
+  "pytest>=9,<10",
   "ruff>=0.1.6,<=0.14.8",
   "pip-audit>=2.5.6,<3",
   "pytest-mock~=3.14",
@@ -35,7 +35,7 @@ dev = [
   "python-dotenv>=1.0.0,<2",
   "sphinx>=8.0.0,<9",
   "poethepoet>=0.19,<0.39",
-  "pytest-httpx>=0.35.0,<0.36",
+  "pytest-httpx>=0.36.0,<0.37",
   "pytest-xdist>=3.6.1,<4",
   "linkify-it-py>=2.0.3,<3",
   "setuptools>=80.9.0,<81",

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,7 @@ wheels = [
 
 [[package]]
 name = "algokit-utils"
-version = "5.0.0a22"
+version = "5.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "exceptiongroup" },

--- a/uv.lock
+++ b/uv.lock
@@ -94,9 +94,9 @@ dev = [
     { name = "pre-commit", specifier = ">=3.4.0,<4" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
     { name = "pydoclint", specifier = ">=0.6.0,<0.9" },
-    { name = "pytest", specifier = ">=8,<9" },
+    { name = "pytest", specifier = ">=9,<10" },
     { name = "pytest-cov", specifier = ">=6,<7" },
-    { name = "pytest-httpx", specifier = ">=0.35.0,<0.36" },
+    { name = "pytest-httpx", specifier = ">=0.36.0,<0.37" },
     { name = "pytest-mock", specifier = "~=3.14" },
     { name = "pytest-sugar", specifier = ">=1.0.0,<2" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4" },
@@ -1479,7 +1479,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1490,9 +1490,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1511,15 +1511,15 @@ wheels = [
 
 [[package]]
 name = "pytest-httpx"
-version = "0.35.0"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/89/5b12b7b29e3d0af3a4b9c071ee92fa25a9017453731a38f08ba01c280f4c/pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f", size = 54146, upload-time = "2024-11-28T19:16:54.237Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/42/f53c58570e80d503ade9dd42ce57f2915d14bcbe25f6308138143950d1d6/pytest_httpx-0.36.2.tar.gz", hash = "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356", size = 57683, upload-time = "2026-04-09T13:57:19.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/ed/026d467c1853dd83102411a78126b4842618e86c895f93528b0528c7a620/pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744", size = 19442, upload-time = "2024-11-28T19:16:52.787Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/55/1fa65f8e4fceb19dd6daa867c162ad845d547f6058cd92b4b02384a44777/pytest_httpx-0.36.2-py3-none-any.whl", hash = "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22", size = 20315, upload-time = "2026-04-09T13:57:18.587Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Move `docs/v5-migration.md` to `docs/src/content/docs/migration/v5-migration-guide.md` so Starlight's autogenerate picks it up in the sidebar
- Add Starlight frontmatter (title + description) matching the v3 guide pattern
- Update `uv.lock` version
- Bump `pytest` and `pytest-httpx` deps

Address #293