### PR TITLE
fix: stringify JS-unsafe integers in AVM simulation traces

### DIFF
--- a/src/algokit_utils/_debugging.py
+++ b/src/algokit_utils/_debugging.py
@@ -30,6 +30,28 @@ DEBUG_TRACES_DIR = "debug_traces"
 TEAL_FILE_EXT = ".teal"
 TEAL_SOURCEMAP_EXT = ".teal.map"
 
+# JS Number.MAX_SAFE_INTEGER — values outside this range lose precision when
+# parsed as JSON numbers by the AVM VS Code debugger (js-algorand-sdk v3).
+_JS_MAX_SAFE_INTEGER = (1 << 53) - 1
+
+
+def prepare_simulate_response_for_avm_debugger(obj: typing.Any) -> typing.Any:  # noqa: ANN401
+    """Prepare a simulate response for AlgoKit AVM Debugger consumption.
+
+    Integers outside JavaScript's ``Number.MAX_SAFE_INTEGER`` are converted to
+    strings so the JS decoder in the AVM VS Code debugger preserves precision.
+    Nested dicts/lists are walked recursively. Booleans are left unchanged.
+    """
+    if isinstance(obj, dict):
+        return {key: prepare_simulate_response_for_avm_debugger(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [prepare_simulate_response_for_avm_debugger(item) for item in obj]
+    if isinstance(obj, int) and not isinstance(obj, bool):
+        if obj > _JS_MAX_SAFE_INTEGER or obj < -_JS_MAX_SAFE_INTEGER:
+            return str(obj)
+        return obj
+    return obj
+
 
 @dataclass
 class AVMDebuggerSourceMapEntry:
@@ -302,5 +324,6 @@ def simulate_and_persist_response(
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
     cleanup_old_trace_files(output_file.parent, buffer_size_mb)
-    output_file.write_text(json.dumps(response.simulate_response, indent=2))
+    safe_response = prepare_simulate_response_for_avm_debugger(response.simulate_response)
+    output_file.write_text(json.dumps(safe_response, indent=2))
     return response

--- a/tests/test_debug_utils.py
+++ b/tests/test_debug_utils.py
@@ -19,6 +19,7 @@ from algokit_utils._debugging import (
     PersistSourceMapInput,
     cleanup_old_trace_files,
     persist_sourcemaps,
+    prepare_simulate_response_for_avm_debugger,
     simulate_and_persist_response,
 )
 from algokit_utils.algorand import AlgorandClient
@@ -378,3 +379,44 @@ def test_does_nothing_when_total_size_within_buffer_limit(
 
     remaining_files = list(trace_dir.iterdir())
     assert len(remaining_files) == 2
+
+
+# Pure unit tests (no LocalNet) for AVM debugger JSON integer safety — #199
+
+_JS_MAX_SAFE = (1 << 53) - 1
+
+
+def test_prepare_simulate_response_stringifies_js_unsafe_integers() -> None:
+    payload = {
+        "last-round": 12345,
+        "safe": _JS_MAX_SAFE,
+        "unsafe-pos": _JS_MAX_SAFE + 1,
+        "unsafe-neg": -(_JS_MAX_SAFE + 1),
+        "uint64-like": 18_446_744_073_709_551_615,
+        "flag": True,
+        "nested": {
+            "stack": [1, _JS_MAX_SAFE + 7, "already-str", False],
+        },
+    }
+
+    result = prepare_simulate_response_for_avm_debugger(payload)
+
+    assert result["last-round"] == 12345
+    assert result["safe"] == _JS_MAX_SAFE
+    assert result["unsafe-pos"] == str(_JS_MAX_SAFE + 1)
+    assert result["unsafe-neg"] == str(-(_JS_MAX_SAFE + 1))
+    assert result["uint64-like"] == "18446744073709551615"
+    assert result["flag"] is True
+    assert result["nested"]["stack"] == [1, str(_JS_MAX_SAFE + 7), "already-str", False]
+
+
+def test_prepare_simulate_response_json_roundtrip_preserves_large_ints_as_strings() -> None:
+    payload = {"pc": 42, "uint": 2**64 - 1, "inner": [{"v": 2**60}]}
+    encoded = json.dumps(prepare_simulate_response_for_avm_debugger(payload))
+    # Large ints must appear quoted in the JSON text (JS-safe).
+    assert '"18446744073709551615"' in encoded
+    assert '"1152921504606846976"' in encoded
+    decoded = json.loads(encoded)
+    assert decoded["uint"] == "18446744073709551615"
+    assert decoded["inner"][0]["v"] == "1152921504606846976"
+    assert decoded["pc"] == 42


### PR DESCRIPTION
## Summary
- When persisting `.trace.avm.json` files, integers outside JavaScript `Number.MAX_SAFE_INTEGER` (`2^53 - 1`) are written as strings.
- Nested dicts/lists are walked recursively; booleans and safe ints are unchanged.
- Adds pure unit tests (no LocalNet required) covering unsafe positives/negatives and JSON round-trip.

## Context
Fixes #199. The AVM VS Code debugger loads traces with js-algorand-sdk v3. Python's `json.dumps` emits arbitrary-precision integers as JSON numbers, which JS then loses precision on. Matching the string-wrapping convention used by the JS decoder fixes the debugger flow for large stack/scratch values.

## Validation
```bash
uv run pytest tests/test_debug_utils.py -k prepare_simulate_response -v
uv run ruff check src/algokit_utils/_debugging.py
```