### PR TITLE
fix: avoid error transformer app id prefix collisions

### DIFF
--- a/src/algokit_utils/applications/app_client.py
+++ b/src/algokit_utils/applications/app_client.py
@@ -166,6 +166,17 @@ def get_constant_block_offset(program: bytes) -> int:  # noqa: C901
     return max(bytecblock_offset or 0, intcblock_offset or 0)
 
 
+def _error_refers_to_app_id(error_message: str, app_id: int) -> bool:
+    """Return True if *error_message* refers to exactly *app_id*.
+
+    Matches ``app={app_id}`` only when the id is not a prefix of a longer numeric id,
+    so a transformer for app ``1142`` does not claim errors for app ``11423``.
+    """
+    import re
+
+    return re.search(rf"app={app_id}(?!\d)", error_message) is not None
+
+
 CreateOnComplete = Literal[
     OnComplete.NoOpOC,
     OnComplete.UpdateApplicationOC,
@@ -2014,9 +2025,9 @@ class AppClient:
                 # Instead check the programs to identify if this is the correct app
                 should_transform = self._is_new_app_error_for_this_app(error)
             else:
-                # Only handle errors for this specific app
-                app_id_string = f"app={self._app_id}"
-                should_transform = app_id_string in str(error)
+                # Only handle errors for this specific app (digit-boundary match avoids
+                # prefix collisions, e.g. app=1142 must not match app=11423).
+                should_transform = _error_refers_to_app_id(str(error), self._app_id)
 
             if not should_transform:
                 # Error is not for this app, return unchanged

--- a/tests/applications/test_error_transformer_app_id.py
+++ b/tests/applications/test_error_transformer_app_id.py
@@ -1,0 +1,35 @@
+"""Pure unit tests for app-id matching in AppClient error transformers (#296)."""
+
+from algokit_utils.applications.app_client import _error_refers_to_app_id
+
+
+def test_error_refers_to_exact_app_id() -> None:
+    message = (
+        "Network request error. Received status 400: "
+        "TransactionPool.Remember: transaction ABC123: logic eval error: "
+        "assert failed pc=42. Details: app=1142, pc=42"
+    )
+    assert _error_refers_to_app_id(message, 1142) is True
+
+
+def test_error_does_not_match_prefix_app_id() -> None:
+    """app=1142 must not match an error that refers to app=11423 (prefix collision)."""
+    message = "transaction XYZ789: logic eval error: assert failed pc=10. Details: app=11423, pc=10"
+    assert _error_refers_to_app_id(message, 1142) is False
+    assert _error_refers_to_app_id(message, 11423) is True
+
+
+def test_error_matches_app_id_at_end_of_string() -> None:
+    assert _error_refers_to_app_id("failed for app=99", 99) is True
+    assert _error_refers_to_app_id("failed for app=99", 9) is False
+
+
+def test_error_matches_app_id_followed_by_non_digit() -> None:
+    assert _error_refers_to_app_id("Details: app=42, pc=7", 42) is True
+    assert _error_refers_to_app_id("Details: app=42; pc=7", 42) is True
+    assert _error_refers_to_app_id("Details: app=42 pc=7", 42) is True
+
+
+def test_error_without_app_id_does_not_match() -> None:
+    assert _error_refers_to_app_id("logic eval error: assert failed pc=1", 1142) is False
+    assert _error_refers_to_app_id("", 1) is False


### PR DESCRIPTION
## Summary
- `AppClient` registers error transformers on the shared `AlgorandClient` and used a substring check (`"app={id}" in str(error)`) to decide ownership.
- That allowed prefix collisions: a transformer for app `1142` matched errors for app `11423`, transforming them with the wrong source map and corrupting `LogicError` messages.
- Match with a digit boundary (`app={id}(?!\d)`) so only the exact app id is claimed.

## Context
Fixes #296.

## Validation
```bash
uv run pytest tests/applications/test_error_transformer_app_id.py -v
uv run ruff check src/algokit_utils/applications/app_client.py tests/applications/test_error_transformer_app_id.py
```