### PR TITLE
chore: pin gitpython to clear pip-audit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
   "pygments>=2.20.0,<3",    # direct dev dep to keep pip-audit off a vulnerable version
   "requests>=2.33.0,<3",    # direct dev dep to keep pip-audit off a vulnerable version
   "filelock>=3.20.1,<4",    # direct dev dep to keep pip-audit off a vulnerable version
+  "gitpython>=3.1.58,<4",   # direct dev dep to keep pip-audit off a vulnerable version
   "pytest-mock>=3.14,<4",
   "mypy>=1.5.1,<2",
   "python-semantic-release>=10,<11",

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "algokit-utils"
-version = "4.2.3"
+version = "4.2.4b2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -31,6 +31,7 @@ dependencies = [
 dev = [
     { name = "click" },
     { name = "filelock" },
+    { name = "gitpython" },
     { name = "linkify-it-py" },
     { name = "mypy" },
     { name = "pip" },
@@ -69,6 +70,7 @@ requires-dist = [
 dev = [
     { name = "click", specifier = ">=8.3.3,<9" },
     { name = "filelock", specifier = ">=3.20.1,<4" },
+    { name = "gitpython", specifier = ">=3.1.58,<4" },
     { name = "linkify-it-py", specifier = ">=2.0.3,<3" },
     { name = "mypy", specifier = ">=1.5.1,<2" },
     { name = "pip", specifier = ">=26.1.2,<27" },
@@ -638,14 +640,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Proposed Changes

- Pin `gitpython>=3.1.58,<4` as a direct dev dependency so `uv run --no-sync pip-audit` no longer fails on the 15 GitPython advisories in 3.1.50.
- Refresh `uv.lock` to GitPython 3.1.59 (latest patched).
- Same pattern already used in this file for `pygments`, `requests`, and `filelock`.

This is why `check-python` is red on #324 and #325: those PRs do not change dependencies, but PR validation runs `pip-audit` against the current lockfile. This pin unblocks them without mixing a lockfile bump into the feature diffs.

## Validation

- [x] `uv lock --upgrade-package gitpython`
- [x] `uv run --no-sync pip-audit` → `No known vulnerabilities found`